### PR TITLE
Auto-resubscribe to channels after reconnecting

### DIFF
--- a/pysher/channel.py
+++ b/pysher/channel.py
@@ -2,12 +2,14 @@ from collections import defaultdict
 
 
 class Channel(object):
-    def __init__(self, channel_name, connection):
+    def __init__(self, channel_name, connection, auth=None):
         self.name = channel_name
 
         self.connection = connection
 
         self.event_callbacks = defaultdict(list)
+
+        self.auth = auth
 
     def bind(self, event_name, callback, *args, **kwargs):
         """Bind an event to a callback
@@ -20,7 +22,7 @@ class Channel(object):
         self.event_callbacks[event_name].append((callback, args, kwargs))
 
     def trigger(self, event_name, data):
-        """Trigger an event on this channel.  Only available for private or 
+        """Trigger an event on this channel.  Only available for private or
         presence channels
 
         :param event_name: The name of the event.  Must begin with 'client-''

--- a/pysher/pusher.py
+++ b/pysher/pusher.py
@@ -21,8 +21,11 @@ class Pusher(object):
         self.channels = {}
         self.url = self._build_url(key, secure, port, custom_host)
 
-        self.connection = Connection(self._connection_handler, self.url, log_level=log_level,
-                                     daemon=daemon, reconnect_interval=reconnect_interval,
+        self.connection = Connection(self._connection_handler, self.url,
+                                     reconnect_handler=self._reconnect_handler,
+                                     log_level=log_level,
+                                     daemon=daemon,
+                                     reconnect_interval=reconnect_interval,
                                      **thread_kwargs)
 
     def connect(self):
@@ -99,6 +102,15 @@ class Pusher(object):
     def _connection_handler(self, event_name, data, channel_name):
         if channel_name in self.channels:
             self.channels[channel_name]._handle_event(event_name, data)
+
+    def _reconnect_handler(self):
+        for channel_name, channel in self.channels.items():
+            data = {'channel': channel_name}
+
+            if channel.auth:
+                data['auth'] = channel.auth
+
+            self.connection.send_event('pusher:subscribe', data)
 
     @staticmethod
     def _generate_private_key(socket_id, key, channel_name, secret):

--- a/pysher/pusher.py
+++ b/pysher/pusher.py
@@ -13,7 +13,8 @@ class Pusher(object):
     protocol = 6
 
     def __init__(self, key, secure=True, secret=None, user_data=None, log_level=logging.INFO,
-                 daemon=True, port=None, reconnect_interval=10, custom_host=None, **thread_kwargs):
+                 daemon=True, port=None, reconnect_interval=10, custom_host=None, auto_sub=False,
+                 **thread_kwargs):
         self.key = key
         self.secret = secret
         self.user_data = user_data or {}
@@ -21,8 +22,13 @@ class Pusher(object):
         self.channels = {}
         self.url = self._build_url(key, secure, port, custom_host)
 
+        if auto_sub:
+            reconnect_handler = self._reconnect_handler
+        else:
+            reconnect_handler = None
+
         self.connection = Connection(self._connection_handler, self.url,
-                                     reconnect_handler=self._reconnect_handler,
+                                     reconnect_handler=reconnect_handler,
                                      log_level=log_level,
                                      daemon=daemon,
                                      reconnect_interval=reconnect_interval,


### PR DESCRIPTION
Currently reconnecting would almost always go silently (i.e. receiving 4200 error). Upon reconnection, Pusher doesn't remember the previously subscribed channels, so the channel objects will then just sit there without receiving any new messages.

This patches the problem by introducing a reconnection handler to Connection class, which is passed from a Pusher object. This handler deals with retrieving the already subscribed channels and resends pusher:subscribe event.

Made this optional and defaulted to False to avoid breaking anyone's existing code.