### PR TITLE
Add support for WebSocket over HTTP proxy

### DIFF
--- a/pysher/connection.py
+++ b/pysher/connection.py
@@ -8,7 +8,7 @@ import json
 
 class Connection(Thread):
     def __init__(self, event_handler, url, reconnect_handler=None, log_level=logging.INFO,
-                 daemon=True, reconnect_interval=10, **thread_kwargs):
+                 daemon=True, reconnect_interval=10, socket_kwargs=None, **thread_kwargs):
         self.event_handler = event_handler
         self.url = url
 
@@ -23,6 +23,7 @@ class Connection(Thread):
         self.needs_reconnect = False
         self.default_reconnect_interval = reconnect_interval
         self.reconnect_interval = reconnect_interval
+        self.socket_kwargs = socket_kwargs or dict()
 
         self.pong_timer = None
         self.pong_received = False
@@ -101,7 +102,7 @@ class Connection(Thread):
             on_close=self._on_close
         )
 
-        self.socket.run_forever()
+        self.socket.run_forever(**self.socket_kwargs)
 
         while self.needs_reconnect and not self.disconnect_called:
             self.logger.info("Attempting to connect again in %s seconds."
@@ -112,7 +113,7 @@ class Connection(Thread):
             # We need to set this flag since closing the socket will set it to
             # false
             self.socket.keep_running = True
-            self.socket.run_forever()
+            self.socket.run_forever(**self.socket_kwargs)
 
     def _on_open(self, ws):
         self.logger.info("Connection: Connection opened")

--- a/pysher/pusher.py
+++ b/pysher/pusher.py
@@ -14,6 +14,7 @@ class Pusher(object):
 
     def __init__(self, key, secure=True, secret=None, user_data=None, log_level=logging.INFO,
                  daemon=True, port=None, reconnect_interval=10, custom_host=None, auto_sub=False,
+                 http_proxy_host=None, http_proxy_port=None, http_no_proxy=None, http_proxy_auth=None,
                  **thread_kwargs):
         self.key = key
         self.secret = secret
@@ -32,6 +33,10 @@ class Pusher(object):
                                      log_level=log_level,
                                      daemon=daemon,
                                      reconnect_interval=reconnect_interval,
+                                     socket_kwargs=dict(http_proxy_host=http_proxy_host,
+                                                        http_proxy_port=http_proxy_port,
+                                                        http_no_proxy=http_no_proxy,
+                                                        http_proxy_auth=http_proxy_auth),
                                      **thread_kwargs)
 
     def connect(self):


### PR DESCRIPTION
Add the following to the `Pusher` constructor, defaulting to `None`:
- `http_proxy_host`
- `http_proxy_port`
- `http_no_proxy`
- `http_proxy_auth`

These are passed to `WebSocketApp.run_forever` and allow Pysher to be used behind an HTTP proxy.