### PR TITLE
Update reconnect flag on open

### DIFF
--- a/pysher/connection.py
+++ b/pysher/connection.py
@@ -119,6 +119,10 @@ class Connection(Thread):
 
     def _on_open(self, ws):
         self.logger.info("Connection: Connection opened")
+        
+        # Since we've opened a connection, we don't need to try to reconnect
+        self.needs_reconnect = False
+        
         # Send a ping right away to inform that the connection is alive. If you
         # don't do this, it takes the ping interval to subcribe to channel and
         # events


### PR DESCRIPTION
PR: When the WebSocketApp opens a connection, we set self.needs_reconnect to False because we don't need a reconnect anymore