### PR TITLE
Make calls to Scheduler.enter and Thread.__init__ compatible with Python 2

### DIFF
--- a/pysher/connection.py
+++ b/pysher/connection.py
@@ -186,8 +186,9 @@ class Connection(Thread):
     def _start_timers(self):
         self._stop_timers()
 
-        self.ping_timer = self.timeout_scheduler.enter(self.ping_interval, 1, self.send_ping)
-        self.connection_timer = self.timeout_scheduler.enter(self.connection_timeout, 2, self._connection_timed_out)
+        self.ping_timer = self.timeout_scheduler.enter(self.ping_interval, 1, self.send_ping, argument=())
+        self.connection_timer = self.timeout_scheduler.enter(self.connection_timeout, 2, self._connection_timed_out,
+                                                             argument=())
 
         if not self.timeout_scheduler_thread:
             self.timeout_scheduler_thread = Thread(target=self.timeout_scheduler.run, daemon=True, name="PysherScheduler")
@@ -227,7 +228,7 @@ class Connection(Thread):
         except Exception as e:
             self.logger.error("Failed send ping: %s" % e)
 
-        self.pong_timer = self.timeout_scheduler.enter(self.pong_timeout, 3, self._check_pong)
+        self.pong_timer = self.timeout_scheduler.enter(self.pong_timeout, 3, self._check_pong, argument=())
 
     def send_pong(self):
         self.logger.info("Connection: pong to pusher")

--- a/pysher/connection.py
+++ b/pysher/connection.py
@@ -191,11 +191,13 @@ class Connection(Thread):
                                                              argument=())
 
         if not self.timeout_scheduler_thread:
-            self.timeout_scheduler_thread = Thread(target=self.timeout_scheduler.run, daemon=True, name="PysherScheduler")
+            self.timeout_scheduler_thread = Thread(target=self.timeout_scheduler.run, name="PysherScheduler")
+            self.timeout_scheduler_thread.daemon = True
             self.timeout_scheduler_thread.start()
 
         elif not self.timeout_scheduler_thread.is_alive():
-            self.timeout_scheduler_thread = Thread(target=self.timeout_scheduler.run, daemon=True, name="PysherScheduler")
+            self.timeout_scheduler_thread = Thread(target=self.timeout_scheduler.run, name="PysherScheduler")
+            self.timeout_scheduler_thread.daemon = True
             self.timeout_scheduler_thread.start()
 
     def _cancel_scheduler_event(self, event):


### PR DESCRIPTION
When using Pysher in a Python 2 runtime, the calls to `Scheduler.enter` fail because the Python 3 function signature is `scheduler.enter(delay, priority, action, argument=(), kwargs={})` and the Python 2 function signature is `scheduler.enter(delay, priority, action, argument)`. 

`Thread.__init__` only takes the `daemon` argument in Python 3, but both Python 2 and Python 3 accept setting `Thread.daemon` via `Thread.daemon = True|False`. 

Hopefully this is a non-contentious fix :) 