### PR TITLE
Fix for other events without data

### DIFF
--- a/pysher/connection.py
+++ b/pysher/connection.py
@@ -163,7 +163,7 @@ class Connection(Thread):
                 # so it can be handled by the appropriate channel.
                 self.event_handler(
                     params['event'],
-                    params['data'],
+                    params.get('data'),
                     params['channel']
                 )
 


### PR DESCRIPTION
Events like `pusher_internal:subscription_succeeded` have no data parameter, giving errors like this one:
> `error from callback <bound method Connection._on_message of <Connection(PysherEventLoop, started daemon 476)>>: 'data'`