### PR TITLE
Updated methods to support new version of websocket-client library

### DIFF
--- a/pysher/connection.py
+++ b/pysher/connection.py
@@ -125,7 +125,7 @@ class Connection(Thread):
             self.socket.keep_running = True
             self.socket.run_forever(**self.socket_kwargs)
 
-    def _on_open(self):
+    def _on_open(self, wp):
         self.logger.info("Connection: Connection opened")
 
         # Send a ping right away to inform that the connection is alive. If you
@@ -134,12 +134,12 @@ class Connection(Thread):
         self.send_ping()
         self._start_timers()
 
-    def _on_error(self, error):
+    def _on_error(self, wp, error):
         self.logger.info("Connection: Error - %s" % error)
         self.state = "failed"
         self.needs_reconnect = True
 
-    def _on_message(self, message):
+    def _on_message(self, wp, message):
         self.logger.info("Connection: Message - %s" % message)
 
         # Stop our timeout timer, since we got some data

--- a/pysher/connection.py
+++ b/pysher/connection.py
@@ -125,7 +125,7 @@ class Connection(Thread):
             self.socket.keep_running = True
             self.socket.run_forever(**self.socket_kwargs)
 
-    def _on_open(self, wp):
+    def _on_open(self, *args):
         self.logger.info("Connection: Connection opened")
 
         # Send a ping right away to inform that the connection is alive. If you
@@ -134,12 +134,13 @@ class Connection(Thread):
         self.send_ping()
         self._start_timers()
 
-    def _on_error(self, wp, error):
-        self.logger.info("Connection: Error - %s" % error)
+    def _on_error(self, *args):
+        self.logger.info("Connection: Error - %s" % args[-1])
         self.state = "failed"
         self.needs_reconnect = True
 
-    def _on_message(self, wp, message):
+    def _on_message(self, *args):
+        message = args[-1]
         self.logger.info("Connection: Message - %s" % message)
 
         # Stop our timeout timer, since we got some data


### PR DESCRIPTION
Due to the fact that the websocket-client library was updated and in this update the functions (on_open, on_message, on_error, on_close) require a new parameter which is an object of type websocket, as referenced in https://github.com/websocket-client/websocket-client. The Pysher library is not able to call these functions due to the lack of this parameter, generating the following error:

"Connection._on_open of <Connection(PysherEventLoop, started daemon 139926242196200)>>: _on_open() takes 1 positional argument but 2 were given."

I have added such parameter to the mentioned functions and with this the error is solved.

In the last commit I solved the bug for previous versions maintaining compatibility